### PR TITLE
[BUGFIX] Lowercase issues on query values

### DIFF
--- a/src/JsonApiQueryParser.js
+++ b/src/JsonApiQueryParser.js
@@ -118,7 +118,7 @@ class JsonApiQueryParser {
    **/
   static parseInclude (includeString, requestDataSubset) {
     // Kept simple for now, does not parse dot-separated relationships (comment.user)
-    let targetString = includeString.toLowerCase().replace('include=', '');
+    let targetString = includeString.split('=')[1];
     requestDataSubset.include = targetString.split(',');
 
     return requestDataSubset;
@@ -191,7 +191,7 @@ class JsonApiQueryParser {
    *
    **/
   static parseSort (sortString, requestDataSubset) {
-    let targetString = sortString.toLowerCase().replace('sort=', '');
+    let targetString = sortString.split('=')[1];
     requestDataSubset.sort = targetString.split(',');
 
     return requestDataSubset;

--- a/test/JsonApiQueryParser.spec.js
+++ b/test/JsonApiQueryParser.spec.js
@@ -45,7 +45,7 @@ describe('JsonApiQueryParser', function () {
       var testString, testData, expectedData;
       var parserClass = new JsonApiQueryParser();
 
-      testString = '//article/5/relationships/comment?include=user,comment&sort=age&&fields[user]=name,email&page[limit]=20&filter[name]=test&filter[age]=15';
+      testString = '//article/5/relationships/comment?include=user,testComment&sort=Age,firstName&&fields[user]=name,email&page[limit]=20&filter[name]=test&filter[age]=15';
       testData = parserClass.parseRequest(testString, requestData);
 
       expectedData = {
@@ -54,8 +54,8 @@ describe('JsonApiQueryParser', function () {
         relationships: true,
         relationshipType: 'comment',
         queryData: {
-          include: ['user', 'comment'],
-          sort: ['age'],
+          include: ['user', 'testComment'],
+          sort: ['Age', 'firstName'],
           fields: {
             user: ['name', 'email']
           },


### PR DESCRIPTION
- Fixed by using split on '=' instead of replace
