### PR TITLE
Added functionality to filter by specified type

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,15 @@ let requestData = {
     fields: {},
     sort: [],
     page: {},
-    filter: {}
+    filter: {},
+    filterType: {
+      like: {},
+      not: {},
+      lt: {},
+      lte: {},
+      gt: {},
+      gte: {}
+    }
   }
 };
 
@@ -67,7 +75,15 @@ let requestData = {
     page: {
       limit: 20
     },
-    filter: {}
+    filter: {},
+    filterType: {
+      like: {},
+      not: {},
+      lt: {},
+      lte: {},
+      gt: {},
+      gte: {}
+    }
   }
 };
 ```
@@ -94,9 +110,12 @@ Filters might not be properly parsed since there are no specifications for this 
 as soon as filtering specs are available.
 For now the filters are handled like the fields parameter.
 
+FilterType is also not supported by JSON API spec. This feature can be used to filter on partial matches, less than, greater than, and more. 
+The feature is currently implemented for [bookshelf-jsonapi-params](https://github.com/scoutforpets/bookshelf-jsonapi-params).
+
 ```js
 //EXAMPLE 1
-let url = '/article/5?filter[name]=john%20doe&filter[age]=15'
+let url = '/article/5?filter[name]=john%20doe&&filterType[lt][age]=15'
 let requestData = {
   resourceType: 'article',
   identifier: '5',
@@ -110,6 +129,16 @@ let requestData = {
     filter: {
       name: 'john doe',
       age: '15'
+    },
+    filterType: {
+      like: {},
+      not: {},
+      lt: {
+        age: '15'
+      },
+      lte: {},
+      gt: {},
+      gte: {}
     }
   }
 };

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ let requestData = {
     fields: {},
     sort: [],
     page: {},
-    filter: {},
-    filterType: {
+    filter: {
       like: {},
       not: {},
       lt: {},
@@ -75,8 +74,7 @@ let requestData = {
     page: {
       limit: 20
     },
-    filter: {},
-    filterType: {
+    filter: {
       like: {},
       not: {},
       lt: {},
@@ -115,7 +113,7 @@ The feature is currently implemented for [bookshelf-jsonapi-params](https://gith
 
 ```js
 //EXAMPLE 1
-let url = '/article/5?filter[name]=john%20doe&&filterType[lt][age]=15'
+let url = '/article/5?filter[name]=john%20doe&&filter[age][lt]=15'
 let requestData = {
   resourceType: 'article',
   identifier: '5',
@@ -128,9 +126,7 @@ let requestData = {
     page: {},
     filter: {
       name: 'john doe',
-      age: '15'
-    },
-    filterType: {
+      age: '15',
       like: {},
       not: {},
       lt: {

--- a/src/JsonApiQueryParser.js
+++ b/src/JsonApiQueryParser.js
@@ -247,13 +247,13 @@ class JsonApiQueryParser {
   static parseFilterType (filterString, requestDataSubset) {
     let targetType;
     let targetColumn;
-    let targetFilterString;
-
-    targetColumn = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1) {
+    let targetFilterString;]
+    
+    targetType = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1, $2) {
       return $1;
     });
-
-    targetType = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1, $2) {
+    
+    targetColumn = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1) {
       return $2;
     });
 

--- a/src/JsonApiQueryParser.js
+++ b/src/JsonApiQueryParser.js
@@ -8,8 +8,8 @@ let PARSE_PARAM = Object.freeze({
   parseFields: /^fields\[(.*?)\]\=.*?$/i,
   parsePage: /^page\[(.*?)\]\=.*?$/i,
   parseSort: /^sort\=(.*?)/i,
-  parseFilter: /^filter\[(.*?)\]\=.*?$/i,
-  parseFilterType: /^filterType\[(.*?)\]\[(.*?)\]\=.*?$/i
+  parseFilter: /^filter\[([^\]]*?)\]\=.*?$/i,
+  parseFilterType: /^filter\[(.*?)\]\[(.*?)\]\=(.*?)$/i
 });
 
 
@@ -33,8 +33,7 @@ class JsonApiQueryParser {
         fields: {},
         sort: [],
         page: {},
-        filter: {},
-        filterType: {
+        filter: {
           like: {},
           not: {},
           lt: {},
@@ -240,7 +239,7 @@ class JsonApiQueryParser {
    * [Note: The are no proper specifications for this parameter yet.
    * For now the filter is implemented similar to the fields parameter. Values should be url encoded to allow for special characters.]
    *
-   * @param {[string]} filterString [Required sort query string piece. Example: "filter[like][name]=John%20Doe".]
+   * @param {[string]} filterString [Required sort query string piece. Example: "filter[name][like]=John%20Doe".]
    * @param {[object]} requestDataSubset [Required reference to the requestData.queryData object.]
    * @return {[object]} requestDataSubset [Returning the modified request data.]
    *
@@ -249,22 +248,21 @@ class JsonApiQueryParser {
     let targetType;
     let targetColumn;
     let targetFilterString;
-    let filterNameRegex = /^filter.*?\=(.*?)$/i;
 
-    targetType = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1, $2, $3) {
+    targetColumn = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1) {
       return $1;
     });
 
-    targetColumn = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1, $2, $3) {
+    targetType = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1, $2) {
       return $2;
     });
 
-    targetFilterString = filterString.replace(filterNameRegex, function(match, $1, $2, $3) {
-      return $1;
+    targetFilterString = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1, $2, $3) {
+      return $3;
     });
 
-    if(requestDataSubset.filterType[targetType]){
-      requestDataSubset.filterType[targetType][targetColumn] = targetFilterString;
+    if(requestDataSubset.filter[targetType]){
+      requestDataSubset.filter[targetType][targetColumn] = targetFilterString;
     }
 
     return requestDataSubset;

--- a/src/JsonApiQueryParser.js
+++ b/src/JsonApiQueryParser.js
@@ -8,7 +8,8 @@ let PARSE_PARAM = Object.freeze({
   parseFields: /^fields\[(.*?)\]\=.*?$/i,
   parsePage: /^page\[(.*?)\]\=.*?$/i,
   parseSort: /^sort\=(.*?)/i,
-  parseFilter: /^filter\[(.*?)\]\=.*?$/i
+  parseFilter: /^filter\[(.*?)\]\=.*?$/i,
+  parseFilterType: /^filterType\[(.*?)\]\[(.*?)\]\=.*?$/i
 });
 
 
@@ -32,7 +33,15 @@ class JsonApiQueryParser {
         fields: {},
         sort: [],
         page: {},
-        filter: {}
+        filter: {},
+        filterType: {
+          like: {},
+          not: {},
+          lt: {},
+          lte: {},
+          gt: {},
+          gte: {}
+        }
       }
     };
 
@@ -223,6 +232,40 @@ class JsonApiQueryParser {
     });
 
     requestDataSubset.filter[targetColumn] = targetFilterString;
+
+    return requestDataSubset;
+  }
+
+  /**
+   * [Note: The are no proper specifications for this parameter yet.
+   * For now the filter is implemented similar to the fields parameter. Values should be url encoded to allow for special characters.]
+   *
+   * @param {[string]} filterString [Required sort query string piece. Example: "filter[like][name]=John%20Doe".]
+   * @param {[object]} requestDataSubset [Required reference to the requestData.queryData object.]
+   * @return {[object]} requestDataSubset [Returning the modified request data.]
+   *
+   **/
+  static parseFilterType (filterString, requestDataSubset) {
+    let targetType;
+    let targetColumn;
+    let targetFilterString;
+    let filterNameRegex = /^filter.*?\=(.*?)$/i;
+
+    targetType = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1, $2, $3) {
+      return $1;
+    });
+
+    targetColumn = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1, $2, $3) {
+      return $2;
+    });
+
+    targetFilterString = filterString.replace(filterNameRegex, function(match, $1, $2, $3) {
+      return $1;
+    });
+
+    if(requestDataSubset.filterType[targetType]){
+      requestDataSubset.filterType[targetType][targetColumn] = targetFilterString;
+    }
 
     return requestDataSubset;
   }

--- a/src/JsonApiQueryParser.js
+++ b/src/JsonApiQueryParser.js
@@ -40,7 +40,7 @@ class JsonApiQueryParser {
     requestData = this.parseEndpoint(urlSplit[0], requestData);
 
     if(urlSplit[1]) {
-      requestData.queryData = this.parseQueryParameters(decodeURIComponent(urlSplit[1]), requestData.queryData);
+      requestData.queryData = this.parseQueryParameters(urlSplit[1], requestData.queryData);
     }
 
     return requestData;
@@ -84,6 +84,9 @@ class JsonApiQueryParser {
    **/
   parseQueryParameters (queryString, requestDataSubset) {
     let querySplit = queryString.split('&');
+    querySplit = querySplit.map(function(queryPart){
+      return decodeURIComponent(queryPart);
+    });
     querySplit.forEach(this.delegateToParser, requestDataSubset);
 
     return requestDataSubset;

--- a/src/JsonApiQueryParser.js
+++ b/src/JsonApiQueryParser.js
@@ -249,11 +249,11 @@ class JsonApiQueryParser {
     let targetColumn;
     let targetFilterString;]
     
-    targetType = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1, $2) {
+    targetType = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1) {
       return $1;
     });
     
-    targetColumn = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1) {
+    targetColumn = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1, $2) {
       return $2;
     });
 

--- a/src/JsonApiQueryParser.js
+++ b/src/JsonApiQueryParser.js
@@ -247,7 +247,7 @@ class JsonApiQueryParser {
   static parseFilterType (filterString, requestDataSubset) {
     let targetType;
     let targetColumn;
-    let targetFilterString;]
+    let targetFilterString;
     
     targetType = filterString.replace(PARSE_PARAM.parseFilterType, function(match, $1) {
       return $1;

--- a/test/JsonApiQueryParser.spec.js
+++ b/test/JsonApiQueryParser.spec.js
@@ -21,7 +21,15 @@ describe('JsonApiQueryParser', function () {
         fields: {},
         sort: [],
         page: {},
-        filter: {}
+        filter: {},
+        filterType: {
+          like: {},
+          not: {},
+          lt: {},
+          lte: {},
+          gt: {},
+          gte: {}
+        }
       }
     };
 
@@ -30,7 +38,15 @@ describe('JsonApiQueryParser', function () {
       fields: {},
       sort: [],
       page: {},
-      filter: {}
+      filter: {},
+      filterType: {
+        like: {},
+        not: {},
+        lt: {},
+        lte: {},
+        gt: {},
+        gte: {}
+      }
     };
   });
 
@@ -45,7 +61,8 @@ describe('JsonApiQueryParser', function () {
       var testString, testData, expectedData;
       var parserClass = new JsonApiQueryParser();
 
-      testString = '//article/5/relationships/comment?include=user,testComment&sort=Age%2CfirstName&&fields[user]=name,email&page[limit]=20&filter[name]=john%20doe&filter[age]=15';
+      testString = '//article/5/relationships/comment?include=user,testComment&sort=Age%2CfirstName&&fields[user]=name,email&page[limit]=20' 
+                    + '&filter[name]=john%20doe&filter[age]=15&filterType[like][name]=john,joe&filterType[not][age]=30&filterType[gt][age]=17';
       testData = parserClass.parseRequest(testString, requestData);
 
       expectedData = {
@@ -65,6 +82,20 @@ describe('JsonApiQueryParser', function () {
           filter: {
             name: 'john doe',
             age: '15'
+          },
+          filterType: {
+            like: {
+              name: 'john,joe'
+            },
+            not: {
+              age: '30'
+            },
+            lt: {},
+            lte: {},
+            gt: {
+              age: '17'
+            },
+            gte: {}
           }
         }
       };
@@ -91,7 +122,15 @@ describe('JsonApiQueryParser', function () {
           fields: {},
           sort: [],
           page: {},
-          filter: {}
+          filter: {},
+          filterType: {
+            like: {},
+            not: {},
+            lt: {},
+            lte: {},
+            gt: {},
+            gte: {}
+          }
         }
       };
 
@@ -110,7 +149,15 @@ describe('JsonApiQueryParser', function () {
           fields: {},
           sort: [],
           page: {},
-          filter: {}
+          filter: {},
+          filterType: {
+            like: {},
+            not: {},
+            lt: {},
+            lte: {},
+            gt: {},
+            gte: {}
+          }
         }
       };
 
@@ -153,6 +200,14 @@ describe('JsonApiQueryParser', function () {
         },
         filter: {
           name: 'test'
+        },
+        filterType: {
+          like: {},
+          not: {},
+          lt: {},
+          lte: {},
+          gt: {},
+          gte: {}
         }
       };
 
@@ -163,10 +218,19 @@ describe('JsonApiQueryParser', function () {
         fields: {},
         sort: [],
         page: {},
-        filter: {}
+        filter: {},
+        filterType: {
+          like: {},
+          not: {},
+          lt: {},
+          lte: {},
+          gt: {},
+          gte: {}
+        }
       };
 
-      testString = '&&include=user&page[offset]=200&sort=age,-id&fields[user]=name,email&&fields[article]=title,body&page[limit]=20&filter[name]=test&filter[lastname]=another';
+      testString = '&&include=user&page[offset]=200&sort=age,-id&fields[user]=name,email&&fields[article]=title,body&page[limit]=20'
+                    + '&filter[name]=test&filter[lastname]=another&filterType[like][name]=boo';
       testData = parserClass.parseQueryParameters(testString, requestDataSubset);
 
       expectedData = {
@@ -183,6 +247,16 @@ describe('JsonApiQueryParser', function () {
         filter: {
           name: 'test',
           lastname: 'another'
+        },
+        filterType: {
+          like: {
+            name: 'boo'
+          },
+          not: {},
+          lt: {},
+          lte: {},
+          gt: {},
+          gte: {}
         }
       };
 
@@ -200,7 +274,15 @@ describe('JsonApiQueryParser', function () {
         fields: {},
         sort: [],
         page: {},
-        filter: {}
+        filter: {},
+        filterType: {
+          like: {},
+          not: {},
+          lt: {},
+          lte: {},
+          gt: {},
+          gte: {}
+        }
       };
 
       expect(testData).to.deep.equal(expectedData);
@@ -229,7 +311,15 @@ describe('JsonApiQueryParser', function () {
         },
         sort: [],
         page: {},
-        filter: {}
+        filter: {},
+        filterType: {
+          like: {},
+          not: {},
+          lt: {},
+          lte: {},
+          gt: {},
+          gte: {}
+        }
       };
 
       expect(testData).to.deep.equal(expectedData);
@@ -256,7 +346,15 @@ describe('JsonApiQueryParser', function () {
           limit: '20',
           offset: '180'
         },
-        filter: {}
+        filter: {},
+        filterType: {
+          like: {},
+          not: {},
+          lt: {},
+          lte: {},
+          gt: {},
+          gte: {}
+        }
       };
 
       expect(testData).to.deep.equal(expectedData);
@@ -273,7 +371,15 @@ describe('JsonApiQueryParser', function () {
         fields: {},
         sort: ['-createdon', 'type'],
         page: {},
-        filter: {}
+        filter: {},
+        filterType: {
+          like: {},
+          not: {},
+          lt: {},
+          lte: {},
+          gt: {},
+          gte: {}
+        }
       };
 
       expect(testData).to.deep.equal(expectedData);
@@ -292,6 +398,14 @@ describe('JsonApiQueryParser', function () {
         page: {},
         filter: {
           id: '5'
+        },
+        filterType: {
+          like: {},
+          not: {},
+          lt: {},
+          lte: {},
+          gt: {},
+          gte: {}
         }
       };
 
@@ -307,6 +421,64 @@ describe('JsonApiQueryParser', function () {
         filter: {
           id: '5',
           name: 'john doe'
+        },
+        filterType: {
+          like: {},
+          not: {},
+          lt: {},
+          lte: {},
+          gt: {},
+          gte: {}
+        }
+      };
+      expect(testData2).to.deep.equal(expectedData2);
+    });
+  });
+
+  describe('parseFilterType function', function() {
+    it('should place the values of the filterType strings to their matching queryData filterType objects.', function() {
+      let filterString = 'filterType[not][name]=jack';
+
+      let testData = JsonApiQueryParser.parseFilterType(filterString, requestDataSubset);
+      let expectedData = {
+        include: [],
+        fields: {},
+        sort: [],
+        page: {},
+        filter: {},
+        filterType: {
+            like: {},
+            not: {
+              name: 'jack'
+            },
+            lt: {},
+            lte: {},
+            gt: {},
+            gte: {}
+        }
+      };
+
+      expect(testData).to.deep.equal(expectedData);
+
+      let filterString2 = 'filterType[lt][age]=24';
+      let testData2 = JsonApiQueryParser.parseFilterType(filterString2, testData);
+      let expectedData2 = {
+        include: [],
+        fields: {},
+        sort: [],
+        page: {},
+        filter: {},
+        filterType: {
+            like: {},
+            not: {
+              name: 'jack'
+            },
+            lt: {
+              age: '24'
+            },
+            lte: {},
+            gt: {},
+            gte: {}
         }
       };
       expect(testData2).to.deep.equal(expectedData2);

--- a/test/JsonApiQueryParser.spec.js
+++ b/test/JsonApiQueryParser.spec.js
@@ -60,7 +60,7 @@ describe('JsonApiQueryParser', function () {
       var parserClass = new JsonApiQueryParser();
 
       testString = '//article/5/relationships/comment?include=user,testComment&sort=Age%2CfirstName&&fields[user]=name,email&page[limit]=20' 
-                    + '&filter[name]=john%20doe&filter[age]=15&filter[name][like]=john,joe&filter[age][not]=30&filter[age][gt]=17';
+                    + '&filter[name]=john%20doe&filter[age]=15&filter[like][name]=john,joe&filter[not][age]=30&filter[gt][age]=17';
       testData = parserClass.parseRequest(testString, requestData);
 
       expectedData = {
@@ -221,7 +221,7 @@ describe('JsonApiQueryParser', function () {
       };
 
       testString = '&&include=user&page[offset]=200&sort=age,-id&fields[user]=name,email&&fields[article]=title,body&page[limit]=20'
-                    + '&filter[name]=test&filter[lastname]=another&filter[name][like]=boo';
+                    + '&filter[name]=test&filter[lastname]=another&filter[like][name]=boo';
       testData = parserClass.parseQueryParameters(testString, requestDataSubset);
 
       expectedData = {
@@ -418,7 +418,7 @@ describe('JsonApiQueryParser', function () {
 
   describe('parseFilterType function', function() {
     it('should place the values of the filterType strings to their matching queryData filterType objects.', function() {
-      let filterString = 'filter[name][not]=jack';
+      let filterString = 'filter[not][name]=jack';
 
       let testData = JsonApiQueryParser.parseFilterType(filterString, requestDataSubset);
       let expectedData = {
@@ -440,7 +440,7 @@ describe('JsonApiQueryParser', function () {
 
       expect(testData).to.deep.equal(expectedData);
 
-      let filterString2 = 'filter[age][lt]=24';
+      let filterString2 = 'filter[lt][age]=24';
       let testData2 = JsonApiQueryParser.parseFilterType(filterString2, testData);
       let expectedData2 = {
         include: [],

--- a/test/JsonApiQueryParser.spec.js
+++ b/test/JsonApiQueryParser.spec.js
@@ -21,8 +21,7 @@ describe('JsonApiQueryParser', function () {
         fields: {},
         sort: [],
         page: {},
-        filter: {},
-        filterType: {
+        filter: {
           like: {},
           not: {},
           lt: {},
@@ -38,8 +37,7 @@ describe('JsonApiQueryParser', function () {
       fields: {},
       sort: [],
       page: {},
-      filter: {},
-      filterType: {
+      filter: {
         like: {},
         not: {},
         lt: {},
@@ -62,7 +60,7 @@ describe('JsonApiQueryParser', function () {
       var parserClass = new JsonApiQueryParser();
 
       testString = '//article/5/relationships/comment?include=user,testComment&sort=Age%2CfirstName&&fields[user]=name,email&page[limit]=20' 
-                    + '&filter[name]=john%20doe&filter[age]=15&filterType[like][name]=john,joe&filterType[not][age]=30&filterType[gt][age]=17';
+                    + '&filter[name]=john%20doe&filter[age]=15&filter[name][like]=john,joe&filter[age][not]=30&filter[age][gt]=17';
       testData = parserClass.parseRequest(testString, requestData);
 
       expectedData = {
@@ -81,9 +79,7 @@ describe('JsonApiQueryParser', function () {
           },
           filter: {
             name: 'john doe',
-            age: '15'
-          },
-          filterType: {
+            age: '15',
             like: {
               name: 'john,joe'
             },
@@ -122,8 +118,7 @@ describe('JsonApiQueryParser', function () {
           fields: {},
           sort: [],
           page: {},
-          filter: {},
-          filterType: {
+          filter: {
             like: {},
             not: {},
             lt: {},
@@ -149,8 +144,7 @@ describe('JsonApiQueryParser', function () {
           fields: {},
           sort: [],
           page: {},
-          filter: {},
-          filterType: {
+          filter: {
             like: {},
             not: {},
             lt: {},
@@ -199,9 +193,7 @@ describe('JsonApiQueryParser', function () {
           limit: '20'
         },
         filter: {
-          name: 'test'
-        },
-        filterType: {
+          name: 'test',
           like: {},
           not: {},
           lt: {},
@@ -218,8 +210,7 @@ describe('JsonApiQueryParser', function () {
         fields: {},
         sort: [],
         page: {},
-        filter: {},
-        filterType: {
+        filter: {
           like: {},
           not: {},
           lt: {},
@@ -230,7 +221,7 @@ describe('JsonApiQueryParser', function () {
       };
 
       testString = '&&include=user&page[offset]=200&sort=age,-id&fields[user]=name,email&&fields[article]=title,body&page[limit]=20'
-                    + '&filter[name]=test&filter[lastname]=another&filterType[like][name]=boo';
+                    + '&filter[name]=test&filter[lastname]=another&filter[name][like]=boo';
       testData = parserClass.parseQueryParameters(testString, requestDataSubset);
 
       expectedData = {
@@ -246,9 +237,7 @@ describe('JsonApiQueryParser', function () {
         },
         filter: {
           name: 'test',
-          lastname: 'another'
-        },
-        filterType: {
+          lastname: 'another',
           like: {
             name: 'boo'
           },
@@ -274,8 +263,7 @@ describe('JsonApiQueryParser', function () {
         fields: {},
         sort: [],
         page: {},
-        filter: {},
-        filterType: {
+        filter: {
           like: {},
           not: {},
           lt: {},
@@ -311,8 +299,7 @@ describe('JsonApiQueryParser', function () {
         },
         sort: [],
         page: {},
-        filter: {},
-        filterType: {
+        filter: {
           like: {},
           not: {},
           lt: {},
@@ -346,8 +333,7 @@ describe('JsonApiQueryParser', function () {
           limit: '20',
           offset: '180'
         },
-        filter: {},
-        filterType: {
+        filter: {
           like: {},
           not: {},
           lt: {},
@@ -371,8 +357,7 @@ describe('JsonApiQueryParser', function () {
         fields: {},
         sort: ['-createdon', 'type'],
         page: {},
-        filter: {},
-        filterType: {
+        filter: {
           like: {},
           not: {},
           lt: {},
@@ -397,9 +382,7 @@ describe('JsonApiQueryParser', function () {
         sort: [],
         page: {},
         filter: {
-          id: '5'
-        },
-        filterType: {
+          id: '5',
           like: {},
           not: {},
           lt: {},
@@ -420,9 +403,7 @@ describe('JsonApiQueryParser', function () {
         page: {},
         filter: {
           id: '5',
-          name: 'john doe'
-        },
-        filterType: {
+          name: 'john doe',
           like: {},
           not: {},
           lt: {},
@@ -437,7 +418,7 @@ describe('JsonApiQueryParser', function () {
 
   describe('parseFilterType function', function() {
     it('should place the values of the filterType strings to their matching queryData filterType objects.', function() {
-      let filterString = 'filterType[not][name]=jack';
+      let filterString = 'filter[name][not]=jack';
 
       let testData = JsonApiQueryParser.parseFilterType(filterString, requestDataSubset);
       let expectedData = {
@@ -445,40 +426,38 @@ describe('JsonApiQueryParser', function () {
         fields: {},
         sort: [],
         page: {},
-        filter: {},
-        filterType: {
-            like: {},
-            not: {
-              name: 'jack'
-            },
-            lt: {},
-            lte: {},
-            gt: {},
-            gte: {}
+        filter: {
+          like: {},
+          not: {
+            name: 'jack'
+          },
+          lt: {},
+          lte: {},
+          gt: {},
+          gte: {}
         }
       };
 
       expect(testData).to.deep.equal(expectedData);
 
-      let filterString2 = 'filterType[lt][age]=24';
+      let filterString2 = 'filter[age][lt]=24';
       let testData2 = JsonApiQueryParser.parseFilterType(filterString2, testData);
       let expectedData2 = {
         include: [],
         fields: {},
         sort: [],
         page: {},
-        filter: {},
-        filterType: {
-            like: {},
-            not: {
-              name: 'jack'
-            },
-            lt: {
-              age: '24'
-            },
-            lte: {},
-            gt: {},
-            gte: {}
+        filter: {
+          like: {},
+          not: {
+            name: 'jack'
+          },
+          lt: {
+            age: '24'
+          },
+          lte: {},
+          gt: {},
+          gte: {}
         }
       };
       expect(testData2).to.deep.equal(expectedData2);


### PR DESCRIPTION
I implemented a feature that allows you to filter by partial matches, not equal, less than (or equal), and greater than (or equal). 

This feature can be used with the Bookshelf JSONAPI Params package. You can find an issue for this feature [here](https://github.com/scoutforpets/bookshelf-jsonapi-params/issues/19), and the pull request with the feature [here](https://github.com/scoutforpets/bookshelf-jsonapi-params/pull/20).

Let me know what you think of this.
