### PR TITLE
Fixed parsing of 'sort' when containing '=' character

### DIFF
--- a/src/JsonApiQueryParser.js
+++ b/src/JsonApiQueryParser.js
@@ -202,7 +202,7 @@ class JsonApiQueryParser {
    *
    **/
   static parseSort (sortString, requestDataSubset) {
-    let targetString = sortString.split(/=(.+)/)[1];
+    let targetString = sortString.split(/=(.+)/)[1] || '';
     requestDataSubset.sort = targetString.split(',');
 
     return requestDataSubset;

--- a/src/JsonApiQueryParser.js
+++ b/src/JsonApiQueryParser.js
@@ -202,7 +202,7 @@ class JsonApiQueryParser {
    *
    **/
   static parseSort (sortString, requestDataSubset) {
-    let targetString = sortString.split('=')[1];
+    let targetString = sortString.split(/=(.+)/)[1];
     requestDataSubset.sort = targetString.split(',');
 
     return requestDataSubset;

--- a/test/JsonApiQueryParser.spec.js
+++ b/test/JsonApiQueryParser.spec.js
@@ -369,6 +369,28 @@ describe('JsonApiQueryParser', function () {
 
       expect(testData).to.deep.equal(expectedData);
     });
+
+    it('should parse a sort value containing an \'=\' character', function() {
+      let sortString = 'sort=-(value1=test),value2';
+
+      let testData = JsonApiQueryParser.parseSort(sortString, requestDataSubset);
+      let expectedData = {
+        include: [],
+        fields: {},
+        sort: ['-(value1=test)', 'value2'],
+        page: {},
+        filter: {
+          like: {},
+          not: {},
+          lt: {},
+          lte: {},
+          gt: {},
+          gte: {}
+        }
+      };
+
+      expect(testData).to.deep.equal(expectedData);
+    });
   });
 
   describe('parseFilter function', function() {


### PR DESCRIPTION
Hey there!

I replaced the `sort` parameter split using a regular expression to fix an issue when it contained an `=` character. For example: `sort=-(value1=test),value2` was parsed to `['-(value1']`. It is now properly parsed to `['-(value1=test)', 'value2']`

Cheers,